### PR TITLE
Utilize own script to publish without make

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -83,4 +83,6 @@ jobs:
           certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
 
       - name: Publish to GitHub
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_GITHUB_TOKEN }}
         run: npm run publish:ci

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -82,8 +82,5 @@ jobs:
           trusted-signing-account-name: ${{ secrets.AZURE_CODE_SIGNING_NAME }}
           certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
 
-      - name: Make distributables
-        run: npm run make -- --skip-package
-
       - name: Publish to GitHub
-        run: npm run publish -- --from-dry-run
+        run: npm run publish:ci

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,6 +14,7 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
+    "publish:ci": "node --loader ts-node/esm scripts/publish-without-make.ts",
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,md}\"",

--- a/packages/app/scripts/publish-without-make.ts
+++ b/packages/app/scripts/publish-without-make.ts
@@ -1,0 +1,7 @@
+import { api as forge } from '@electron-forge/core';
+
+await forge.publish({
+  makeOptions: {
+    skipPackage: true,
+  },
+});


### PR DESCRIPTION
* Removes make step and replaces with `publish:ci`
* Utilize Forge API to skip package step since it is packaged and code-signed