### PR TITLE
Finalize Windows Support

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [macos-latest, macos-13, windows-latest]
+        platform: [macos-latest, windows-latest]
 
     defaults:
       run:

--- a/packages/app/forge.config.cts
+++ b/packages/app/forge.config.cts
@@ -127,7 +127,10 @@ const config: ForgeConfig = {
   },
   rebuildConfig: {},
   makers: [
-    new MakerSquirrel({}),
+    new MakerSquirrel({
+      setupIcon: './icons/icon.ico',
+      iconUrl: 'https://gettoolbase.ai/logo.ico',
+    }),
     new MakerZIP({}, ['darwin']),
     //@ts-expect-error MakerDMS has incorrect types.
     new MakerDMG({

--- a/packages/app/package-lock.json
+++ b/packages/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "toolbase",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toolbase",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "dependencies": {
         "@mantine/core": "^7.14.3",
         "@mantine/form": "^7.14.3",

--- a/packages/app/src/main/ipc-listeners.ts
+++ b/packages/app/src/main/ipc-listeners.ts
@@ -32,11 +32,11 @@ async function refreshClaude() {
 
   try {
     if (platform === 'win32') {
-      await execAsync('taskkill /F /IM "Claude.exe" && start "" "Claude.exe"');
+      await execAsync('taskkill /F /IM "Claude.exe"');
     } else if (platform === 'darwin') {
-      await execAsync('killall "Claude" && open -a "Claude"');
+      await execAsync('killall "Claude"');
     } else if (platform === 'linux') {
-      await execAsync('pkill -f "claude" && claude');
+      await execAsync('pkill -f "claude"');
     }
   } catch (error) {
     console.error('Failed to close Claude, assuming it is not running', error);
@@ -46,13 +46,18 @@ async function refreshClaude() {
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
   // Reopen the app
-  if (platform === 'win32') {
-    await execAsync('start "" "Claude.exe"');
-  } else if (platform === 'darwin') {
-    await execAsync('open -a "Claude"');
-  } else if (platform === 'linux') {
-    await execAsync('claude');
+  try {
+    if (platform === 'win32') {
+      await execAsync('start "" "%LocalAppData%\\AnthropicClaude\\Claude.exe"');
+    } else if (platform === 'darwin') {
+      await execAsync('open -a "Claude"');
+    } else if (platform === 'linux') {
+      await execAsync('claude');
+    }
+  } catch (error) {
+    console.error('Failed to open Claude', error);
   }
+ 
 }
 
 /**

--- a/packages/app/src/main/main.ts
+++ b/packages/app/src/main/main.ts
@@ -14,14 +14,16 @@ const createWindow = () => {
   const mainWindow = new BrowserWindow({
     width: 1280,
     height: 720,
-    minWidth: 320,
+    minWidth: 360,
     minHeight: 400,
     webPreferences: {
       preload: join(import.meta.dirname, 'preload.js'),
+      devTools: !app.isPackaged,
     },
     show: false,
+    autoHideMenuBar: true,
   });
-
+  
   mainWindow.once('ready-to-show', () => {
     mainWindow.show();
   });

--- a/packages/runner/mod.ts
+++ b/packages/runner/mod.ts
@@ -26,7 +26,7 @@ if (!moduleName) {
 process.argv = ["", "", ...args["--"]];
 
 // Load and bundle up the module.
-const loadCache = createCache({ root: args.cacheRoot });
+const loadCache = createCache({ root: args.cacheRoot, readOnly: Deno.build.os === "windows" });
 const result = await bundle(moduleName, {
   load(specifier, _isDynamic, cacheSetting, checksum) {
     // If the specifier is a node module, just return it as external.


### PR DESCRIPTION
* Added icon for the installer
* Changed restart logic to better lookup defaults for Claude
* Changed runner to use read only and not the cache directory for bundled modules - there is potentially a Deno cache_dir error when compiled for Windows
* Sets minimum width so it looks better on Windows
* Removes Intel x64 runner for Mac since there is an issue with signing the runner binary